### PR TITLE
Added PUT requests for `/evs/{id}` & `/carmodels/{id}`

### DIFF
--- a/routers/carmodels.py
+++ b/routers/carmodels.py
@@ -42,17 +42,18 @@ async def get_car_models(query: str = None, db: Session = Depends(get_db)):
 @router.put("/carmodels/{id}")
 async def update_car_model(id: int, form: CarModelCreate, db: Session = Depends(get_db)):
  
-    old_model_id = db.query(CarModel).filter(CarModel.id == id).update(
+    model_id = db.query(CarModel).filter(CarModel.id == id).update(
         {
             "model_name": form.name,
             "model_year": form.year,
             "battery_capacity": form.battery_capacity,
             "max_charging_power": form.max_charging_power
-         })
+         }
+    )
     
-    if not old_model_id:
+    if not model_id:
         raise HTTPException(status_code=404, detail=f"Car Model with given id: '{id}' was not found")
     
     db.commit()
 
-    return form
+    return {"detail": f"Car Model with id: '{id}' updated successfully"}

--- a/routers/carmodels.py
+++ b/routers/carmodels.py
@@ -38,3 +38,21 @@ async def get_car_models(query: str = None, db: Session = Depends(get_db)):
     else:
         models = db.query(CarModel).all()
     return models
+
+@router.put("/carmodels/{id}")
+async def update_car_model(id: int, form: CarModelCreate, db: Session = Depends(get_db)):
+ 
+    old_model_id = db.query(CarModel).filter(CarModel.id == id).update(
+        {
+            "model_name": form.name,
+            "model_year": form.year,
+            "battery_capacity": form.battery_capacity,
+            "max_charging_power": form.max_charging_power
+         })
+    
+    if not old_model_id:
+        raise HTTPException(status_code=404, detail=f"Car Model with given id: '{id}' was not found")
+    
+    db.commit()
+
+    return form

--- a/routers/evs.py
+++ b/routers/evs.py
@@ -72,3 +72,19 @@ async def delete_ev_by_id(id: int, db: Session = Depends(get_db)):
     db.delete(ev)
     db.commit()
     return {"detail": "EV deleted successfully"}
+
+@router.put("/evs/{id}")
+async def put_ev_by_id(id: int, ev_create: EvCreate, db: Session = Depends(get_db)): # IGNORES 'car_model_id' wether its provided or not
+    ev_id = db.query(UserEV).filter(UserEV.id == id).update(
+        {
+            "user_set_name":ev_create.name,
+            "current_charge": ev_create.battery_level,
+        }
+    )
+
+    if not ev_id:
+        raise HTTPException(status_code=404, detail=f"EV with given id '{id}' was not found")
+    
+    db.commit()
+    return {"detail": f"EV with id: '{id}' updated successfully"}
+


### PR DESCRIPTION
De skal bruges så frontenden kan redigere i dem :)

PUT `/evs/{id}` ignorerer `car_model_id`. Tænkte det ville være en hovedpine rent praktisk hvis man måtte det, dog hvis det er i strid mod nogle standarder eller noget kan jeg kan også bare sørge for at frontenden ikke rører ved det. 